### PR TITLE
Sätt inte highway=cycleway på vägar

### DIFF
--- a/process_and_resolve.py
+++ b/process_and_resolve.py
@@ -656,7 +656,11 @@ def resolve_highways(way_db, small_road_resolve_algorithm):
             else:
                 raise RuntimeError(f"Unknown GCM-typ {gcmtyp} for {way.rlid}")
 
-        elif "NVDB_cykelvagkat" in way.tags:
+        # NOTE: Some ways are double tagged with both
+        #       Cykelvägskategorier and Gatutyp/Vägtyp.
+        elif "NVDB_cykelvagkat" in way.tags \
+             and "NVDB_gatutyp" not in way.tags \
+             and "KLASS" not in way.tags:
             # value is one of "Regional cykelväg", "Huvudcykelväg", "Lokal cykelväg", we tag all the same
             tags["highway"] = "cycleway"
             tags["foot"] = "yes"


### PR DESCRIPTION
En del vägar är taggade med "Cykelvägskategorier" och "Gatutyp" (eller "Funktionell vägklass"). Exampel: 
<img width="691" height="359" alt="image" src="https://github.com/user-attachments/assets/60010882-0bed-45cb-b1dd-a034d3de470d" />
https://nvdbpakarta.trafikverket.se/map?&backgroundLayer=1LantmaterietsTopowebbkartaNedtonad&wmslayers=Cykelvagskategorier|FunktionellVagklass|Gatutyp|VagnatOchNoder|Vagtyp&east=644172.2089872096&north=6644527.353137601&scale=2131.06924

Det hade kanske varit snyggare att flytta runt alla `elif` istället, men jag vill inte peta för mycket i saker jag inte förstår.